### PR TITLE
[TASK-9] [Logic] As a user, I can answer survey's questions or go back

### DIFF
--- a/app/src/main/java/co/nimblehq/data/model/QuestionResponsesEntity.kt
+++ b/app/src/main/java/co/nimblehq/data/model/QuestionResponsesEntity.kt
@@ -1,0 +1,28 @@
+package co.nimblehq.data.model
+
+import co.nimblehq.data.api.request.AnswerRequest
+import co.nimblehq.data.api.request.QuestionResponsesRequest
+
+data class QuestionResponsesEntity(
+    val id: String,
+    var answers: List<AnswerEntity>
+)
+
+data class AnswerEntity(
+    val id: String,
+    var answer: String? = null
+)
+
+fun QuestionResponsesEntity.toQuestionRequest() = QuestionResponsesRequest(
+    id = id,
+    answers = answers.toAnswerRequests()
+)
+
+fun List<QuestionResponsesEntity>.toQuestionRequests() = this.map { it.toQuestionRequest() }
+
+fun AnswerEntity.toAnswerRequest() = AnswerRequest(
+    id = id,
+    answer = answer
+)
+
+fun List<AnswerEntity>.toAnswerRequests() = this.map { it.toAnswerRequest() }

--- a/app/src/main/java/co/nimblehq/extension/ArrayAdapterExtension.kt
+++ b/app/src/main/java/co/nimblehq/extension/ArrayAdapterExtension.kt
@@ -1,0 +1,9 @@
+package co.nimblehq.extension
+
+import android.widget.ArrayAdapter
+
+fun <T> ArrayAdapter<T>.refreshWithData(list: List<T>) {
+    clear()
+    addAll(list)
+    notifyDataSetChanged()
+}

--- a/app/src/main/java/co/nimblehq/ui/common/dialog/ConfirmExitSurveyDialog.kt
+++ b/app/src/main/java/co/nimblehq/ui/common/dialog/ConfirmExitSurveyDialog.kt
@@ -1,5 +1,6 @@
 package co.nimblehq.ui.common.dialog
 
+import android.annotation.SuppressLint
 import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -10,16 +11,20 @@ import kotlinx.android.synthetic.main.dialog_confirm_exit_survey.view.*
 
 class ConfirmExitSurveyDialog(private val confirmCallback: () -> Unit): DialogFragment() {
 
+    @SuppressLint("InflateParams")
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val dialog = Dialog(context, R.style.FullScreenDialogStyle)
+        val dialog = Dialog(requireContext(), R.style.FullScreenDialogStyle)
         dialog.window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_FULLSCREEN
-        val view = LayoutInflater.from(context).inflate(R.layout.dialog_confirm_exit_survey, null)
-        view.tvConfirmExitSurveyYes.setOnClickListener {
+        val view = LayoutInflater.from(requireContext()).inflate(R.layout.dialog_confirm_exit_survey, null)
+        view.clConfirmExitSurveyDialog.setOnClickListener {
             dismiss()
-            confirmCallback.invoke()
         }
         view.tvConfirmExitSurveyCancel.setOnClickListener {
             dismiss()
+        }
+        view.tvConfirmExitSurveyYes.setOnClickListener {
+            dismiss()
+            confirmCallback.invoke()
         }
         dialog.setContentView(view)
         return dialog

--- a/app/src/main/java/co/nimblehq/ui/common/dialog/ConfirmExitSurveyDialog.kt
+++ b/app/src/main/java/co/nimblehq/ui/common/dialog/ConfirmExitSurveyDialog.kt
@@ -1,0 +1,28 @@
+package co.nimblehq.ui.common.dialog
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import androidx.fragment.app.DialogFragment
+import co.nimblehq.R
+import kotlinx.android.synthetic.main.dialog_confirm_exit_survey.view.*
+
+class ConfirmExitSurveyDialog(private val confirmCallback: () -> Unit): DialogFragment() {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = Dialog(context, R.style.FullScreenDialogStyle)
+        dialog.window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_FULLSCREEN
+        val view = LayoutInflater.from(context).inflate(R.layout.dialog_confirm_exit_survey, null)
+        view.tvConfirmExitSurveyYes.setOnClickListener {
+            dismiss()
+            confirmCallback.invoke()
+        }
+        view.tvConfirmExitSurveyCancel.setOnClickListener {
+            dismiss()
+        }
+        dialog.setContentView(view)
+        return dialog
+    }
+
+}

--- a/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/SurveyDetailsFragment.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/SurveyDetailsFragment.kt
@@ -13,6 +13,7 @@ import co.nimblehq.data.lib.extension.subscribeOnClick
 import co.nimblehq.extension.*
 import co.nimblehq.ui.base.BaseFragment
 import co.nimblehq.ui.base.BaseFragmentCallbacks
+import co.nimblehq.ui.common.dialog.ConfirmExitSurveyDialog
 import co.nimblehq.ui.screen.main.MainNavigator
 import co.nimblehq.ui.screen.main.surveydetails.adapter.QuestionPagerAdapter
 import co.nimblehq.ui.screen.main.surveydetails.uimodel.QuestionItemPagerUiModel
@@ -54,8 +55,9 @@ class SurveyDetailsFragment : BaseFragment(), BaseFragmentCallbacks {
         }.bindForDisposable()
 
         btSurveyQuestionsClose.subscribeOnClick {
-            // TODO: Show confirm close survey questions popup
-            navigator.navigateBack()
+            ConfirmExitSurveyDialog {
+                navigator.navigateBack()
+            }.show(childFragmentManager, "confirm_exit_survey")
         }.bindForDisposable()
 
         btSurveyQuestionsItemNext.subscribeOnClick {

--- a/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/SurveyDetailsFragment.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/SurveyDetailsFragment.kt
@@ -61,7 +61,6 @@ class SurveyDetailsFragment : BaseFragment(), BaseFragmentCallbacks {
         }.bindForDisposable()
 
         btSurveyQuestionsItemNext.subscribeOnClick {
-            // TODO: Handle check to show next page or not
             viewModel.inputs.triggerNextQuestion()
         }.bindForDisposable()
 

--- a/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/adapter/QuestionItemChoiceAdapter.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/adapter/QuestionItemChoiceAdapter.kt
@@ -10,6 +10,7 @@ import co.nimblehq.ui.common.adapter.DiffUpdateAdapter
 import co.nimblehq.ui.screen.main.surveydetails.uimodel.AnswerItemUiModel
 import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.item_survey_questions_choice_answer.*
+import timber.log.Timber
 import kotlin.properties.Delegates
 
 interface ViewHolderClickListener {
@@ -28,6 +29,8 @@ internal class QuestionItemChoiceAdapter :
             { oldItem, newItem -> oldItem.id == newItem.id }
         )
     }
+
+    var onItemsSelected: ((answerUiModels: List<AnswerItemUiModel>) -> Unit)? = null
 
     var pickValue: QuestionPickValue = QuestionPickValue.NONE
 
@@ -58,8 +61,11 @@ internal class QuestionItemChoiceAdapter :
                 selectedIds.clear()
                 selectedIds.add(answer.id)
             }
+            else -> {
+                Timber.d("Not handled Question's pick value")
+            }
         }
-
+        onItemsSelected?.invoke(uiModels.filter { selectedIds.contains(it.id) })
         notifyDataSetChanged()
     }
 

--- a/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/adapter/QuestionItemNpsAdapter.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/adapter/QuestionItemNpsAdapter.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import co.nimblehq.R
+import co.nimblehq.data.lib.common.DEFAULT_UNSELECTED_INDEX
 import co.nimblehq.ui.common.adapter.DiffUpdateAdapter
 import co.nimblehq.ui.screen.main.surveydetails.uimodel.AnswerItemUiModel
 import kotlinx.android.extensions.LayoutContainer
@@ -26,7 +27,9 @@ internal class QuestionItemNpsAdapter :
         )
     }
 
-    private var selectedIndex: Int = 0
+    var onItemsSelected: ((answerUiModels: List<AnswerItemUiModel>) -> Unit)? = null
+
+    private var selectedIndex: Int = DEFAULT_UNSELECTED_INDEX
 
     override fun getItemCount() = uiModels.size
 
@@ -43,6 +46,7 @@ internal class QuestionItemNpsAdapter :
         if (selectedIndex != position) {
             selectedIndex = position
             notifyDataSetChanged()
+            onItemsSelected?.invoke(listOf(uiModels[selectedIndex]))
         }
     }
 

--- a/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/adapter/QuestionItemSliderAdapter.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/adapter/QuestionItemSliderAdapter.kt
@@ -42,10 +42,10 @@ internal class QuestionItemSliderAdapter :
 
     override fun onTap(position: Int) {
         val answer = uiModels[position]
-         if (selectedId != answer.id) {
-             selectedId = answer.id
-             notifyDataSetChanged()
-             onItemsSelected?.invoke(listOf(answer))
+        if (selectedId != answer.id) {
+            selectedId = answer.id
+            notifyDataSetChanged()
+            onItemsSelected?.invoke(listOf(answer))
         }
     }
 

--- a/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/adapter/QuestionItemSliderAdapter.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/adapter/QuestionItemSliderAdapter.kt
@@ -25,6 +25,8 @@ internal class QuestionItemSliderAdapter :
         )
     }
 
+    var onItemsSelected: ((answerUiModels: List<AnswerItemUiModel>) -> Unit)? = null
+
     private var selectedId: String = ""
 
     override fun getItemCount() = uiModels.size
@@ -40,12 +42,11 @@ internal class QuestionItemSliderAdapter :
 
     override fun onTap(position: Int) {
         val answer = uiModels[position]
-        selectedId = if (selectedId == answer.id) {
-            ""
-        } else {
-            answer.id
+         if (selectedId != answer.id) {
+             selectedId = answer.id
+             notifyDataSetChanged()
+             onItemsSelected?.invoke(listOf(answer))
         }
-        notifyDataSetChanged()
     }
 
     override fun onBindViewHolder(holder: QuestionSliderAnswerViewHolder, position: Int) {

--- a/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/adapter/QuestionItemTextFieldAdapter.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/adapter/QuestionItemTextFieldAdapter.kt
@@ -1,10 +1,13 @@
 package co.nimblehq.ui.screen.main.surveydetails.adapter
 
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import co.nimblehq.R
+import co.nimblehq.data.api.request.QuestionRequest
 import co.nimblehq.ui.common.adapter.DiffUpdateAdapter
 import co.nimblehq.ui.screen.main.surveydetails.uimodel.AnswerItemUiModel
 import kotlinx.android.extensions.LayoutContainer
@@ -23,6 +26,10 @@ internal class QuestionItemTextFieldAdapter :
             { oldItem, newItem -> oldItem.id == newItem.id }
         )
     }
+
+    var onItemsTextChanged: ((answerUiModels: List<AnswerItemUiModel>) -> Unit)? = null
+
+    private val answers: MutableList<AnswerItemUiModel> = mutableListOf()
 
     override fun getItemCount() = uiModels.size
 
@@ -50,10 +57,22 @@ internal class QuestionItemTextFieldAdapter :
             get() = itemView
 
         fun bind(uiModel: AnswerItemUiModel) {
-            with(uiModel) {
-                etTextFieldQuestionItemAnswer.hint = text
+            etTextFieldQuestionItemAnswer.hint = uiModel.text
+            etTextFieldQuestionItemAnswer.addTextChangedListener(object : TextWatcher {
+                override fun afterTextChanged(s: Editable?) {
+                    val newAnswerText = s?.toString() ?: ""
+                    answers.firstOrNull { it.id == uiModel.id }?.let {
+                        it.text = newAnswerText
+                    } ?: run {
+                        answers.add(AnswerItemUiModel(uiModel.id, newAnswerText))
+                    }
+                    onItemsTextChanged?.invoke(answers)
+                }
 
-            }
+                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { }
+
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) { }
+            })
         }
     }
 }

--- a/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/adapter/QuestionItemTextFieldAdapter.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/adapter/QuestionItemTextFieldAdapter.kt
@@ -1,17 +1,14 @@
 package co.nimblehq.ui.screen.main.surveydetails.adapter
 
-import android.text.Editable
-import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.widget.doAfterTextChanged
 import androidx.recyclerview.widget.RecyclerView
 import co.nimblehq.R
-import co.nimblehq.data.api.request.QuestionRequest
 import co.nimblehq.ui.common.adapter.DiffUpdateAdapter
 import co.nimblehq.ui.screen.main.surveydetails.uimodel.AnswerItemUiModel
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.item_survey_questions_choice_answer.*
 import kotlinx.android.synthetic.main.item_survey_questions_text_field_answer.*
 import kotlin.properties.Delegates
 
@@ -58,21 +55,15 @@ internal class QuestionItemTextFieldAdapter :
 
         fun bind(uiModel: AnswerItemUiModel) {
             etTextFieldQuestionItemAnswer.hint = uiModel.text
-            etTextFieldQuestionItemAnswer.addTextChangedListener(object : TextWatcher {
-                override fun afterTextChanged(s: Editable?) {
-                    val newAnswerText = s?.toString() ?: ""
-                    answers.firstOrNull { it.id == uiModel.id }?.let {
-                        it.text = newAnswerText
-                    } ?: run {
-                        answers.add(AnswerItemUiModel(uiModel.id, newAnswerText))
-                    }
-                    onItemsTextChanged?.invoke(answers)
+            etTextFieldQuestionItemAnswer.doAfterTextChanged { editable ->
+                val newAnswerText = editable?.toString().orEmpty()
+                answers.firstOrNull { it.id == uiModel.id }?.let {
+                    it.text = newAnswerText
+                } ?: run {
+                    answers.add(AnswerItemUiModel(uiModel.id, newAnswerText))
                 }
-
-                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { }
-
-                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) { }
-            })
+                onItemsTextChanged?.invoke(answers)
+            }
         }
     }
 }

--- a/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/uimodel/AnswerItemUiModel.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/uimodel/AnswerItemUiModel.kt
@@ -4,7 +4,7 @@ import co.nimblehq.data.model.Answer
 
 data class AnswerItemUiModel(
     val id: String,
-    val text: String
+    var text: String
 )
 
 fun Answer.toAnswerItemUiModel() = AnswerItemUiModel(

--- a/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/uimodel/QuestionItemPagerUiModel.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/uimodel/QuestionItemPagerUiModel.kt
@@ -11,7 +11,12 @@ data class QuestionItemPagerUiModel(
     val displayType: QuestionDisplayType,
     val pick: QuestionPickValue,
     val answers: List<AnswerItemUiModel>
-)
+) {
+    val shouldAnswer: Boolean
+    get() {
+        return displayType != QuestionDisplayType.INTRO && displayType != QuestionDisplayType.OUTRO && displayType != QuestionDisplayType.DEFAULT && answers.isNotEmpty()
+    }
+}
 
 fun Question.toQuestionItemPagerUiModel() =
     QuestionItemPagerUiModel(

--- a/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/uimodel/QuestionItemPagerUiModel.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/uimodel/QuestionItemPagerUiModel.kt
@@ -13,9 +13,12 @@ data class QuestionItemPagerUiModel(
     val answers: List<AnswerItemUiModel>
 ) {
     val shouldAnswer: Boolean
-    get() {
-        return displayType != QuestionDisplayType.INTRO && displayType != QuestionDisplayType.OUTRO && displayType != QuestionDisplayType.DEFAULT && answers.isNotEmpty()
-    }
+        get() {
+            return displayType != QuestionDisplayType.INTRO &&
+                displayType != QuestionDisplayType.OUTRO &&
+                displayType != QuestionDisplayType.DEFAULT &&
+                answers.isNotEmpty()
+        }
 }
 
 fun Question.toQuestionItemPagerUiModel() =

--- a/app/src/main/res/drawable/bg_confirm_exit_survey_dialog.xml
+++ b/app/src/main/res/drawable/bg_confirm_exit_survey_dialog.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="@dimen/_12sdp"/>
+    <solid android:color="@color/nero0_90a"/>
+</shape>

--- a/app/src/main/res/drawable/fg_general_divider.xml
+++ b/app/src/main/res/drawable/fg_general_divider.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <size
-        android:height="@dimen/_1sdp"
-        android:width="@dimen/_1sdp" />
+        android:height="@dimen/divider_height"
+        android:width="@dimen/divider_width" />
     <solid android:color="@color/white" />
 </shape>

--- a/app/src/main/res/layout/dialog_confirm_exit_survey.xml
+++ b/app/src/main/res/layout/dialog_confirm_exit_survey.xml
@@ -1,0 +1,94 @@
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/clConfirmExitSurveyDialog"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/black_60a">
+
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/clConfirmExitSurveyDialogContainer"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_confirm_exit_survey_dialog"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_percent="0.8">
+
+        <TextView
+            android:id="@+id/tvConfirmExitSurveyTitle"
+            style="@style/Widget.Template.TextView.Header"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/_12sdp"
+            android:layout_marginTop="@dimen/_14sdp"
+            android:layout_marginEnd="@dimen/_12sdp"
+            android:gravity="center"
+            android:text="@string/confirm_exit_survey_title"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tvConfirmExitSurveyMessage"
+            style="@style/Widget.Template.TextView.Description"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/_12sdp"
+            android:layout_marginTop="@dimen/_1sdp"
+            android:layout_marginEnd="@dimen/_12sdp"
+            android:gravity="center"
+            android:text="@string/confirm_exit_survey_message"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tvConfirmExitSurveyTitle" />
+
+        <View
+            android:id="@+id/vConfirmExitSurveyHorizontalDivider"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/divider_height"
+            android:layout_marginTop="@dimen/_16sdp"
+            android:background="@color/nero1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tvConfirmExitSurveyMessage" />
+
+        <View
+            android:id="@+id/vConfirmExitSurveyVerticalDivider"
+            android:layout_width="@dimen/divider_width"
+            android:layout_height="@dimen/_34sdp"
+            android:background="@color/nero1"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/vConfirmExitSurveyHorizontalDivider" />
+
+        <TextView
+            android:id="@+id/tvConfirmExitSurveyYes"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:gravity="center"
+            android:text="@string/confirm_exit_survey_yes"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@+id/vConfirmExitSurveyVerticalDivider"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/vConfirmExitSurveyHorizontalDivider" />
+
+        <TextView
+            android:id="@+id/tvConfirmExitSurveyCancel"
+            style="@style/Widget.Template.TextView.Bold"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:gravity="center"
+            android:text="@string/confirm_exit_survey_cancel"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/tvConfirmExitSurveyYes"
+            app:layout_constraintTop_toBottomOf="@+id/vConfirmExitSurveyHorizontalDivider" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_survey_questions_nps_answer.xml
+++ b/app/src/main/res/layout/item_survey_questions_nps_answer.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/clChoiceQuestionItemAnswerViewHolder"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content">
@@ -16,7 +15,6 @@
         android:layout_marginTop="@dimen/_10sdp"
         android:layout_marginEnd="@dimen/_5sdp"
         android:layout_marginBottom="@dimen/_10sdp"
-        android:text="@string/text"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/colors_palette.xml
+++ b/app/src/main/res/values/colors_palette.xml
@@ -17,6 +17,8 @@
 
     <color name="dark_blue">#303F9F</color>
 
+    <color name="dodger_blue">#007AFF</color>
+
     <color name="light_blue">#3F51B5</color>
     <color name="light_blue_90a">#903F51B5</color>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,4 +1,6 @@
 <resources>
     <dimen name="ci_size">@dimen/_6sdp</dimen>
+    <dimen name="divider_height">@dimen/_1sdp</dimen>
+    <dimen name="divider_width">@dimen/_1sdp</dimen>
     <dimen name="nav_header_height">@dimen/_129sdp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens_text.xml
+++ b/app/src/main/res/values/dimens_text.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="dimen_normal_display_text">14sp</dimen>
+    <dimen name="dimen_normal_display_text">@dimen/_13ssp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,9 @@
 <resources>
     <string name="app_name">Nimble Surveys</string>
+    <string name="confirm_exit_survey_cancel">Cancel</string>
+    <string name="confirm_exit_survey_message">Are you sure you want to quit the survey?</string>
+    <string name="confirm_exit_survey_title">Warning!</string>
+    <string name="confirm_exit_survey_yes">Yes</string>
     <string name="forget_password_reset_password_instruction">Enter your email to receive instructions for resetting your password.</string>
     <string name="forget_password_reset_btn_title">Reset</string>
     <string name="general_get_survey_details_error">Getting survey details failed. Please try again</string>
@@ -20,5 +24,4 @@
     <string name="survey_questions_text_area_hint">Hint</string>
     <string name="survey_questions_text_field_hint">Hint</string>
     <string name="surveys_today">Today</string>
-    <string name="text">text</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -13,6 +13,21 @@
         <item name="android:windowTranslucentStatus">true</item>
     </style>
 
+    <style name="FadeInOutDialogAnimStyle">
+        <item name="android:windowEnterAnimation">@android:anim/fade_in</item>
+        <item name="android:windowExitAnimation">@android:anim/fade_out</item>
+    </style>
+
+    <style name="FullScreenDialogStyle" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowFullscreen">true</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowBackground">@color/transparent</item>
+        <item name="android:statusBarColor">@color/transparent</item>
+        <item name="android:navigationBarColor">@color/transparent</item>
+        <item name="android:backgroundDimEnabled">true</item>
+        <item name="android:windowAnimationStyle">@style/FadeInOutDialogAnimStyle</item>
+    </style>
+
     <style name="NavigationViewStyle">
         <item name="android:textSize">@dimen/_15ssp</item> <!-- menu item text size-->
         <item name="android:listPreferredItemHeightSmall">@dimen/_35sdp</item><!-- menu item height-->

--- a/app/src/main/res/values/widget_styles.xml
+++ b/app/src/main/res/values/widget_styles.xml
@@ -12,12 +12,12 @@
     <!-- TextView styles -->
     <style name="Widget.Template.TextView" parent="@android:style/Widget.TextView">
         <item name="android:fontFamily">@font/circularstd_book</item>
-        <item name="android:textColor">@color/dark_blue</item>
+        <item name="android:textColor">@color/dodger_blue</item>
         <item name="android:textSize">@dimen/dimen_normal_display_text</item>
     </style>
 
     <style name="Widget.Template.TextView.Bold">
-        <item name="android:textColor">@color/light_blue_90a</item>
+        <item name="android:textColor">@color/dodger_blue</item>
         <item name="android:fontFamily">@font/circularstd_bold</item>
     </style>
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        build_gradle_version = '4.1.0'
+        build_gradle_version = '4.1.1'
 
         android_version_code = 1
         android_version_name = "0.1.0"

--- a/data/src/main/java/co/nimblehq/data/api/request/SubmitSurveyRequest.kt
+++ b/data/src/main/java/co/nimblehq/data/api/request/SubmitSurveyRequest.kt
@@ -1,0 +1,18 @@
+package co.nimblehq.data.api.request
+
+import com.squareup.moshi.Json
+
+data class SubmitSurveyRequest(
+    @Json(name = "survey_id") val surveyId: String,
+    @Json(name = "questions") var questions: List<QuestionRequest>
+)
+
+data class QuestionRequest(
+    @Json(name = "id") val id: String,
+    @Json(name = "answers") var answers: List<AnswerRequest>
+)
+
+data class AnswerRequest(
+    @Json(name = "id") val id: String,
+    @Json(name = "answer") var answer: String? = null
+)

--- a/data/src/main/java/co/nimblehq/data/api/request/SubmitSurveyResponsesRequest.kt
+++ b/data/src/main/java/co/nimblehq/data/api/request/SubmitSurveyResponsesRequest.kt
@@ -2,12 +2,12 @@ package co.nimblehq.data.api.request
 
 import com.squareup.moshi.Json
 
-data class SubmitSurveyRequest(
+data class SubmitSurveyResponsesRequest(
     @Json(name = "survey_id") val surveyId: String,
-    @Json(name = "questions") var questions: List<QuestionRequest>
+    @Json(name = "questions") var questions: List<QuestionResponsesRequest>
 )
 
-data class QuestionRequest(
+data class QuestionResponsesRequest(
     @Json(name = "id") val id: String,
     @Json(name = "answers") var answers: List<AnswerRequest>
 )

--- a/data/src/main/java/co/nimblehq/data/api/request/helper/RequestHelper.kt
+++ b/data/src/main/java/co/nimblehq/data/api/request/helper/RequestHelper.kt
@@ -41,24 +41,4 @@ object RequestHelper {
             questions
         )
     }
-
-    fun surveyQuestion(
-        questionId: String,
-        answers: List<AnswerRequest>
-    ): QuestionRequest {
-        return QuestionRequest(
-            questionId,
-            answers
-        )
-    }
-
-    fun surveyAnswer(
-        answerId: String,
-        answer: String?
-    ): AnswerRequest {
-        return AnswerRequest(
-            answerId,
-            answer
-        )
-    }
 }

--- a/data/src/main/java/co/nimblehq/data/api/request/helper/RequestHelper.kt
+++ b/data/src/main/java/co/nimblehq/data/api/request/helper/RequestHelper.kt
@@ -2,10 +2,7 @@ package co.nimblehq.data.api.request.helper
 
 import co.nimblehq.data.lib.common.OAUTH_GRANT_TYPE_PASSWORD
 import co.nimblehq.data.api.common.secrets.Secrets
-import co.nimblehq.data.api.request.AnswerRequest
 import co.nimblehq.data.api.request.OAuthRequest.*
-import co.nimblehq.data.api.request.QuestionRequest
-import co.nimblehq.data.api.request.SubmitSurveyRequest
 import co.nimblehq.data.lib.common.OAUTH_GRANT_TYPE_REFRESH_TOKEN
 
 object RequestHelper {
@@ -29,16 +26,6 @@ object RequestHelper {
             refreshToken,
             Secrets.clientId,
             Secrets.clientSecret
-        )
-    }
-
-    fun submitSurveyAnswers(
-        surveyId: String,
-        questions: List<QuestionRequest>
-    ): SubmitSurveyRequest {
-        return SubmitSurveyRequest(
-            surveyId,
-            questions
         )
     }
 }

--- a/data/src/main/java/co/nimblehq/data/api/request/helper/RequestHelper.kt
+++ b/data/src/main/java/co/nimblehq/data/api/request/helper/RequestHelper.kt
@@ -2,7 +2,10 @@ package co.nimblehq.data.api.request.helper
 
 import co.nimblehq.data.lib.common.OAUTH_GRANT_TYPE_PASSWORD
 import co.nimblehq.data.api.common.secrets.Secrets
+import co.nimblehq.data.api.request.AnswerRequest
 import co.nimblehq.data.api.request.OAuthRequest.*
+import co.nimblehq.data.api.request.QuestionRequest
+import co.nimblehq.data.api.request.SubmitSurveyRequest
 import co.nimblehq.data.lib.common.OAUTH_GRANT_TYPE_REFRESH_TOKEN
 
 object RequestHelper {
@@ -26,6 +29,36 @@ object RequestHelper {
             refreshToken,
             Secrets.clientId,
             Secrets.clientSecret
+        )
+    }
+
+    fun submitSurveyAnswers(
+        surveyId: String,
+        questions: List<QuestionRequest>
+    ): SubmitSurveyRequest {
+        return SubmitSurveyRequest(
+            surveyId,
+            questions
+        )
+    }
+
+    fun surveyQuestion(
+        questionId: String,
+        answers: List<AnswerRequest>
+    ): QuestionRequest {
+        return QuestionRequest(
+            questionId,
+            answers
+        )
+    }
+
+    fun surveyAnswer(
+        answerId: String,
+        answer: String?
+    ): AnswerRequest {
+        return AnswerRequest(
+            answerId,
+            answer
         )
     }
 }


### PR DESCRIPTION
https://github.com/minhnimble/android-surveys-list/projects/1#card-46087099

## What happened

When taking a survey, users will be able to answer survey's questions, swipe to navigate through the questions and/or stop taking the survey at anytime.

This PR is for creating the logic when to navigate next question, add confirm exit answering survey popup and store user input as answers. 🛠
 
## Insight

- [x] Implement display questions logic
- [x] Implement stop taking survey logic
- [x] Implement store selected answers logic
 
## Proof Of Work

Confirm exit answering survey logic popup:
<img src="https://user-images.githubusercontent.com/70877098/97971151-2d5a0780-1df5-11eb-9118-e481cce2ab0e.png" width="300">

Display question logic that requires user has to answer before processing to next question except INTRO, OUTRO and DEFAULT questions:
![Screen Recording 2020-11-03 at 16 58 38](https://user-images.githubusercontent.com/70877098/97971967-6e9ee700-1df6-11eb-83d3-5e94cb0e7665.gif)
