### PR TITLE
[Chores] Improve view models architecture by adding Output interfaces for observables

### DIFF
--- a/app/src/main/java/co/nimblehq/data/model/Question.kt
+++ b/app/src/main/java/co/nimblehq/data/model/Question.kt
@@ -1,6 +1,7 @@
 package co.nimblehq.data.model
 
 import co.nimblehq.data.api.response.survey.QuestionResponse
+import java.util.*
 
 enum class QuestionDisplayType {
     INTRO,
@@ -21,7 +22,7 @@ enum class QuestionDisplayType {
         fun from(value: String?): QuestionDisplayType {
             value ?: return DEFAULT
             return try {
-                valueOf(value.toUpperCase())
+                valueOf(value.toUpperCase(Locale.ROOT))
             } catch (ex: Exception) {
                 DEFAULT
             }
@@ -38,7 +39,7 @@ enum class QuestionPickValue {
         fun from(value: String?): QuestionPickValue {
             value ?: return NONE
             return try {
-                valueOf(value.toUpperCase())
+                valueOf(value.toUpperCase(Locale.ROOT))
             } catch (ex: Exception) {
                 NONE
             }

--- a/app/src/main/java/co/nimblehq/data/model/Question.kt
+++ b/app/src/main/java/co/nimblehq/data/model/Question.kt
@@ -22,7 +22,7 @@ enum class QuestionDisplayType {
         fun from(value: String?): QuestionDisplayType {
             value ?: return DEFAULT
             return try {
-                valueOf(value.toUpperCase(Locale.ROOT))
+                valueOf(value.toUpperCase(Locale.getDefault()))
             } catch (ex: Exception) {
                 DEFAULT
             }
@@ -39,7 +39,7 @@ enum class QuestionPickValue {
         fun from(value: String?): QuestionPickValue {
             value ?: return NONE
             return try {
-                valueOf(value.toUpperCase(Locale.ROOT))
+                valueOf(value.toUpperCase(Locale.getDefault()))
             } catch (ex: Exception) {
                 NONE
             }

--- a/app/src/main/java/co/nimblehq/ui/screen/main/MainActivity.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/main/MainActivity.kt
@@ -16,7 +16,8 @@ interface LoaderAnimatable {
 @AndroidEntryPoint
 class MainActivity : BaseActivity(), LoaderAnimatable {
 
-    @Inject lateinit var navigator: MainNavigator
+    @Inject
+    lateinit var navigator: MainNavigator
 
     private val viewModel by viewModels<MainViewModel>()
 

--- a/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/SurveyDetailsFragment.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/SurveyDetailsFragment.kt
@@ -26,7 +26,8 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class SurveyDetailsFragment : BaseFragment(), BaseFragmentCallbacks {
 
-    @Inject lateinit var navigator: MainNavigator
+    @Inject
+    lateinit var navigator: MainNavigator
 
     private lateinit var questionPagerAdapter: QuestionPagerAdapter
 
@@ -62,7 +63,7 @@ class SurveyDetailsFragment : BaseFragment(), BaseFragmentCallbacks {
         }.bindForDisposable()
 
         btSurveyQuestionsItemNext.subscribeOnClick {
-            viewModel.inputs.triggerNextQuestion()
+            viewModel.input.triggerNextQuestion()
         }.bindForDisposable()
 
         btSurveyQuestionsSubmit.subscribeOnClick {
@@ -77,37 +78,37 @@ class SurveyDetailsFragment : BaseFragment(), BaseFragmentCallbacks {
 
             override fun onPageSelected(position: Int) {
                 super.onPageSelected(position)
-                viewModel.inputs.currentQuestionIndex(position)
+                viewModel.input.currentQuestionIndex(position)
             }
         })
     }
 
     override fun bindViewModel() {
-        viewModel.currentQuestionIndex
+        viewModel.output.currentQuestionIndex
             .subscribe(::bindCurrentQuestionIndex)
             .bindForDisposable()
 
-        viewModel.showError
+        viewModel.output.showError
             .subscribe(::displayError)
             .bindForDisposable()
 
-        viewModel.questionIndicator
+        viewModel.output.questionIndicator
             .subscribe(::bindQuestionIndicator)
             .bindForDisposable()
 
-        viewModel.questionItemPagerUiModels
+        viewModel.output.questionItemPagerUiModels
             .subscribe(::bindQuestionItemPagerUiModels)
             .bindForDisposable()
 
-        viewModel.reachedLastQuestion
+        viewModel.output.reachedLastQuestion
             .subscribe(::bindReachedLastQuestion)
             .bindForDisposable()
 
-        viewModel.showLoading
+        viewModel.output.showLoading
             .subscribe(::bindShowLoading)
             .bindForDisposable()
 
-        viewModel.showSuccessOverlay
+        viewModel.output.showSuccessOverlay
             .subscribe(::bindShowSuccessOverlay)
             .bindForDisposable()
     }
@@ -137,7 +138,7 @@ class SurveyDetailsFragment : BaseFragment(), BaseFragmentCallbacks {
             hideSurveyDetailsUI()
             showSurveyQuestionsPagerUI()
             questionPagerAdapter.uiModels = uiModels
-            viewModel.inputs.currentQuestionIndex(FIRST_INDEX)
+            viewModel.input.currentQuestionIndex(FIRST_INDEX)
         } else {
             displayError(AppError(null, null, R.string.general_no_question_error))
         }

--- a/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/SurveyDetailsViewModel.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/main/surveydetails/SurveyDetailsViewModel.kt
@@ -15,43 +15,60 @@ import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
 
-interface Inputs {
+interface Input {
+
     fun currentQuestionIndex(index: Int)
 
     fun triggerNextQuestion()
 }
 
+interface Output {
+
+    val showError: Observable<Throwable>
+
+    val showLoading: Observable<Boolean>
+
+    val showSuccessOverlay: Observable<Boolean>
+
+    val currentQuestionIndex: Observable<Int>
+
+    val questionItemPagerUiModels: Observable<List<QuestionItemPagerUiModel>>
+
+    val reachedLastQuestion: Observable<Boolean>
+
+    val questionIndicator: Observable<String>
+}
+
 class SurveyDetailsViewModel @ViewModelInject constructor(
     private val loadSurveyDetailsSingleUseCase: LoadSurveyDetailsSingleUseCase,
     private val submitSurveyResponsesCompletableUseCase: SubmitSurveyResponsesCompletableUseCase
-) : BaseViewModel(), Inputs {
+) : BaseViewModel(), Input, Output {
+
+    val input = this
+
+    val output = this
 
     private val _showError = PublishSubject.create<Throwable>()
-
-    private val _showLoading = BehaviorSubject.create<Boolean>()
-
-    private val _showSuccessOverlay = PublishSubject.create<Boolean>()
-
-    private val _currentQuestionIndex = BehaviorSubject.create<Int>()
-
-    private val _questionItemPagerUiModels = BehaviorSubject.create<List<QuestionItemPagerUiModel>>()
-
-    private val currentQuestionIndexValue: Int
-        get() = _currentQuestionIndex.value ?: DEFAULT_UNSELECTED_INDEX
-
-    private val currentQuestionItemPagerUiModels: List<QuestionItemPagerUiModel>
-        get() = _questionItemPagerUiModels.value.orEmpty()
-
-    val showError: Observable<Throwable>
+    override val showError: Observable<Throwable>
         get() = _showError
 
-    val showLoading: Observable<Boolean>
+    private val _showLoading = BehaviorSubject.create<Boolean>()
+    override val showLoading: Observable<Boolean>
         get() = _showLoading
 
-    val showSuccessOverlay: Observable<Boolean>
+    private val _showSuccessOverlay = PublishSubject.create<Boolean>()
+    override val showSuccessOverlay: Observable<Boolean>
         get() = _showSuccessOverlay
 
-    val reachedLastQuestion: Observable<Boolean>
+    private val _currentQuestionIndex = BehaviorSubject.create<Int>()
+    override val currentQuestionIndex: Observable<Int>
+        get() = _currentQuestionIndex
+
+    private val _questionItemPagerUiModels = BehaviorSubject.create<List<QuestionItemPagerUiModel>>()
+    override val questionItemPagerUiModels: Observable<List<QuestionItemPagerUiModel>>
+        get() = _questionItemPagerUiModels
+
+    override val reachedLastQuestion: Observable<Boolean>
         get() = Observables.combineLatest(
             _currentQuestionIndex,
             _questionItemPagerUiModels
@@ -59,7 +76,7 @@ class SurveyDetailsViewModel @ViewModelInject constructor(
             selectedIndex == questions.size - 1
         }
 
-    val questionIndicator: Observable<String>
+    override val questionIndicator: Observable<String>
         get() = Observables.combineLatest(
             _currentQuestionIndex,
             _questionItemPagerUiModels
@@ -67,13 +84,11 @@ class SurveyDetailsViewModel @ViewModelInject constructor(
             "${selectedIndex + 1}/${questions.size}"
         }
 
-    val currentQuestionIndex: Observable<Int>
-        get() = _currentQuestionIndex
+    private val currentQuestionIndexValue: Int
+        get() = _currentQuestionIndex.value ?: DEFAULT_UNSELECTED_INDEX
 
-    val questionItemPagerUiModels: Observable<List<QuestionItemPagerUiModel>>
-        get() = _questionItemPagerUiModels
-
-    val inputs: Inputs = this
+    private val currentQuestionItemPagerUiModels: List<QuestionItemPagerUiModel>
+        get() = _questionItemPagerUiModels.value.orEmpty()
 
     override fun currentQuestionIndex(index: Int) {
         _currentQuestionIndex.onNext(index)

--- a/app/src/main/java/co/nimblehq/ui/screen/main/surveys/SurveysFragment.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/main/surveys/SurveysFragment.kt
@@ -25,7 +25,8 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class SurveysFragment: BaseFragment(), BaseFragmentCallbacks, NavigationView.OnNavigationItemSelectedListener {
 
-    @Inject lateinit var navigator: MainNavigator
+    @Inject
+    lateinit var navigator: MainNavigator
 
     private val viewModel by viewModels<SurveysViewModel>()
 
@@ -40,14 +41,14 @@ class SurveysFragment: BaseFragment(), BaseFragmentCallbacks, NavigationView.OnN
     }
 
     override fun setupView() {
-        tvSurveysDate.text = Date().toDisplayFormat(DATE_FORMAT_SHORT_DISPLAY).toUpperCase()
+        tvSurveysDate.text = Date().toDisplayFormat(DATE_FORMAT_SHORT_DISPLAY).toUpperCase(Locale.ROOT)
 
         srlSurveys.setOnRefreshListener { viewModel.refreshSurveysList() }
     }
 
     override fun bindViewEvents() {
         btSurveysItemNext.subscribeOnClick {
-            viewModel.getSelectedSurveyUiModel()?.let {
+            viewModel.output.selectedSurveyUiModel?.let {
                 navigator.navigateToSurveyDetails(it)
             }
         }.bindForDisposable()
@@ -56,12 +57,12 @@ class SurveysFragment: BaseFragment(), BaseFragmentCallbacks, NavigationView.OnN
 
             override fun onSwipeLeft() {
                 super.onSwipeLeft()
-                viewModel.inputs.nextIndex()
+                viewModel.input.nextIndex()
             }
 
             override fun onSwipeRight() {
                 super.onSwipeRight()
-                viewModel.inputs.previousIndex()
+                viewModel.input.previousIndex()
             }
         })
 
@@ -73,23 +74,23 @@ class SurveysFragment: BaseFragment(), BaseFragmentCallbacks, NavigationView.OnN
     }
 
     override fun bindViewModel() {
-        viewModel.error
+        viewModel.output.error
             .subscribe(::bindError)
             .bindForDisposable()
 
-        viewModel.showLoading
+        viewModel.output.showLoading
             .subscribe(::bindLoading)
             .bindForDisposable()
 
-        viewModel.showRefreshing
+        viewModel.output.showRefreshing
             .subscribe(::bindRefreshing)
             .bindForDisposable()
 
-        viewModel.selectedSurveyIndex
+        viewModel.output.selectedSurveyIndex
             .subscribe(::bindSelectedSurveyIndex)
             .bindForDisposable()
 
-        viewModel.surveyItemUiModels
+        viewModel.output.surveyItemUiModels
             .subscribe(::bindSurveyItemUiModels)
             .bindForDisposable()
     }
@@ -120,18 +121,17 @@ class SurveysFragment: BaseFragment(), BaseFragmentCallbacks, NavigationView.OnN
     }
 
     private fun bindSelectedSurveyIndex(index: Int) {
-        val surveyUiModel = viewModel.getSelectedSurveyUiModel()
-        if (surveyUiModel != null) {
+        viewModel.output.selectedSurveyUiModel?.let {
             ciSurveysIndicator.animatePageSelected(index)
-            tvSurveysItemHeader.switchTextWithFadeAnimation(surveyUiModel.header)
-            tvSurveysItemDescription.switchTextWithFadeAnimation(surveyUiModel.description)
-            ivSurveysItemBackground.loadImageWithFadeAnimation(surveyUiModel.imageUrl)
+            tvSurveysItemHeader.switchTextWithFadeAnimation(it.header)
+            tvSurveysItemDescription.switchTextWithFadeAnimation(it.description)
+            ivSurveysItemBackground.loadImageWithFadeAnimation(it.imageUrl)
         }
     }
 
     private fun bindSurveyItemUiModels(uiModels: List<SurveyItemUiModel>) {
         if (uiModels.isEmpty()) return
-        ciSurveysIndicator.createIndicators(uiModels.size, viewModel.selectedSurveyIndexValue)
+        ciSurveysIndicator.createIndicators(uiModels.size, viewModel.output.selectedSurveyIndexValue)
     }
 
     private fun toggleDrawer(shouldShow: Boolean) {

--- a/app/src/main/java/co/nimblehq/ui/screen/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/onboarding/OnboardingActivity.kt
@@ -17,7 +17,8 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class OnboardingActivity : BaseActivity(), BlurAnimatable {
 
-    @Inject lateinit var navigator: OnboardingNavigator
+    @Inject
+    lateinit var navigator: OnboardingNavigator
 
     private val viewModel by viewModels<OnboardingViewModel>()
 
@@ -41,7 +42,7 @@ class OnboardingActivity : BaseActivity(), BlurAnimatable {
     }
 
     private fun bindViewModel() {
-        viewModel.error
+        viewModel.output.error
             .subscribeBy {
                 when (it) {
                     is RefreshTokenError -> displayError(TokenExpiredError(null))
@@ -49,7 +50,7 @@ class OnboardingActivity : BaseActivity(), BlurAnimatable {
             }
             .bindForDisposable()
 
-        viewModel.navigator
+        viewModel.output.navigator
             .subscribeBy {
                 when (it) {
                     is NavigationEvent.Onboarding.Main -> showMainActivity()

--- a/app/src/main/java/co/nimblehq/ui/screen/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/onboarding/OnboardingViewModel.kt
@@ -12,20 +12,27 @@ import io.reactivex.Observable
 import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.subjects.PublishSubject
 
+interface Output {
+
+    val error: Observable<Throwable>
+
+    val navigator: Observable<NavigationEvent>
+}
+
 class OnboardingViewModel @ViewModelInject constructor(
     private val getLocalTokenSingleUseCase: GetLocalUserTokenSingleUseCase,
     private val refreshTokenIfNeededSingleUseCase: RefreshTokenIfNeededSingleUseCase,
     private val updateLocalUserTokenCompletableUseCase: UpdateLocalUserTokenCompletableUseCase
-) : BaseViewModel() {
+) : BaseViewModel(), Output {
+
+    val output = this
 
     private val _error = PublishSubject.create<Throwable>()
-
-    private val _navigator = PublishSubject.create<NavigationEvent>()
-
-    val error: Observable<Throwable>
+    override val error: Observable<Throwable>
         get() = _error
 
-    val navigator: Observable<NavigationEvent>
+    private val _navigator = PublishSubject.create<NavigationEvent>()
+    override val navigator: Observable<NavigationEvent>
         get() = _navigator
 
     fun checkSession() {

--- a/app/src/main/java/co/nimblehq/ui/screen/onboarding/signin/SignInFragment.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/onboarding/signin/SignInFragment.kt
@@ -23,7 +23,8 @@ interface BlurAnimatable {
 @AndroidEntryPoint
 class SignInFragment: BaseFragment(), BaseFragmentCallbacks {
 
-    @Inject lateinit var navigator: OnboardingNavigator
+    @Inject
+    lateinit var navigator: OnboardingNavigator
 
     private val viewModel by viewModels<SignInViewModel>()
 
@@ -39,11 +40,11 @@ class SignInFragment: BaseFragment(), BaseFragmentCallbacks {
             .bindForDisposable()
 
         etSignInEmail.addTextChangedListener {
-            viewModel.inputs.email(it.toString())
+            viewModel.input.email(it.toString())
         }
 
         etSignInPassword.addTextChangedListener {
-            viewModel.inputs.password(it.toString())
+            viewModel.input.password(it.toString())
         }
 
         RxBus.listen(PostSessionCheckEvent::class.java)
@@ -52,19 +53,19 @@ class SignInFragment: BaseFragment(), BaseFragmentCallbacks {
     }
 
     override fun bindViewModel() {
-        viewModel.enableLoginButton
+        viewModel.output.enableLoginButton
             .subscribe(::bindEnableLoginButton)
             .bindForDisposable()
 
-        viewModel.signInError
+        viewModel.output.signInError
             .subscribe(::displayError)
             .bindForDisposable()
 
-        viewModel.showLoading
+        viewModel.output.showLoading
             .subscribe(::bindLoading)
             .bindForDisposable()
 
-        viewModel.navigator
+        viewModel.output.navigator
             .subscribe {
                 when (it) {
                     is NavigationEvent.SignIn.Main -> showMainActivity()
@@ -74,7 +75,7 @@ class SignInFragment: BaseFragment(), BaseFragmentCallbacks {
     }
 
     private fun executePostSessionCheck() {
-        if (viewModel.firstInitialized) {
+        if (viewModel.output.firstInitialized) {
             ivSignInNimbleLogo.startFadeInAnimation {
                 // Animate to show blur image on background of the current fragment's activity if it conforms BlurAnimatable
                 (activity as? BlurAnimatable)?.animateBlurBackground()
@@ -89,7 +90,7 @@ class SignInFragment: BaseFragment(), BaseFragmentCallbacks {
                 btSignInForgotPassword.startFadeInAnimation()
                 llSignInInputContainer.startFadeInAnimation()
             }
-            viewModel.inputs.initialized(false)
+            viewModel.input.initialized(false)
         } else {
             ivSignInNimbleLogo.startFadeInAnimation(0)
             clSignIn.animateResource(

--- a/app/src/main/java/co/nimblehq/ui/screen/onboarding/signin/SignInViewModel.kt
+++ b/app/src/main/java/co/nimblehq/ui/screen/onboarding/signin/SignInViewModel.kt
@@ -12,7 +12,8 @@ import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
 
-interface Inputs {
+interface Input {
+
     fun email(input: String)
 
     fun password(input: String)
@@ -20,26 +21,31 @@ interface Inputs {
     fun initialized(input: Boolean)
 }
 
+interface Output {
+
+    val signInError: Observable<Throwable>
+
+    val showLoading: Observable<Boolean>
+
+    val navigator: Observable<NavigationEvent>
+
+    val firstInitialized: Boolean
+
+    val enableLoginButton: Observable<Boolean>
+}
+
 class SignInViewModel @ViewModelInject constructor(
     private val loginByPasswordSingleUseCase: LoginByPasswordSingleUseCase,
     private val updateLocalUserTokenCompletableUseCase: UpdateLocalUserTokenCompletableUseCase
-) : BaseViewModel(), Inputs {
+) : BaseViewModel(), Input, Output {
+
+    val input = this
+
+    val output = this
 
     private val _email = BehaviorSubject.create<String>()
-
     private val _password = BehaviorSubject.create<String>()
-
-    private val _signInError = PublishSubject.create<Throwable>()
-
-    private val _showLoading = BehaviorSubject.create<Boolean>()
-
-    private val _navigator = PublishSubject.create<NavigationEvent>()
-
-    private var _firstInitialized = true
-
-    val inputs: Inputs = this
-
-    val enableLoginButton: Observable<Boolean>
+    override val enableLoginButton: Observable<Boolean>
         get() = Observables.combineLatest(
             _email,
             _password
@@ -47,16 +53,20 @@ class SignInViewModel @ViewModelInject constructor(
             password.isNotEmpty() && email.isEmail()
         }
 
-    val signInError: Observable<Throwable>
+    private val _signInError = PublishSubject.create<Throwable>()
+    override val signInError: Observable<Throwable>
         get() = _signInError
 
-    val showLoading: Observable<Boolean>
+    private val _showLoading = BehaviorSubject.create<Boolean>()
+    override val showLoading: Observable<Boolean>
         get() = _showLoading
 
-    val navigator: Observable<NavigationEvent>
+    private val _navigator = PublishSubject.create<NavigationEvent>()
+    override val navigator: Observable<NavigationEvent>
         get() = _navigator
 
-    val firstInitialized: Boolean
+    private var _firstInitialized = true
+    override val firstInitialized: Boolean
         get() = _firstInitialized
 
     fun login() {

--- a/app/src/test/java/co/nimblehq/ui/screen/onboarding/signin/SignInViewModelTest.kt
+++ b/app/src/test/java/co/nimblehq/ui/screen/onboarding/signin/SignInViewModelTest.kt
@@ -44,8 +44,8 @@ class SignInViewModelTest {
             .signInError
             .test()
 
-        signingViewModel.inputs.email("invalid@nimblehq.co")
-        signingViewModel.inputs.password("12345678")
+        signingViewModel.input.email("invalid@nimblehq.co")
+        signingViewModel.input.password("12345678")
         signingViewModel.login()
 
         // Assert
@@ -78,8 +78,8 @@ class SignInViewModelTest {
             .navigator
             .test()
 
-        signingViewModel.inputs.email("valid@nimblehq.co")
-        signingViewModel.inputs.password("12345678")
+        signingViewModel.input.email("valid@nimblehq.co")
+        signingViewModel.input.password("12345678")
         signingViewModel.login()
 
         // Assert
@@ -97,8 +97,8 @@ class SignInViewModelTest {
             .test()
 
         // Act
-        signingViewModel.inputs.email("acbd")
-        signingViewModel.inputs.password("12345678")
+        signingViewModel.input.email("acbd")
+        signingViewModel.input.password("12345678")
 
         // Assert
         enableLoginButtonObserver
@@ -115,8 +115,8 @@ class SignInViewModelTest {
             .test()
 
         // Act
-        signingViewModel.inputs.email("test@nimblehq.co")
-        signingViewModel.inputs.password("")
+        signingViewModel.input.email("test@nimblehq.co")
+        signingViewModel.input.password("")
 
         // Assert
         enableLoginButtonObserver
@@ -133,8 +133,8 @@ class SignInViewModelTest {
             .test()
 
         // Act
-        signingViewModel.inputs.email("test@nimblehq.co")
-        signingViewModel.inputs.password("12345678")
+        signingViewModel.input.email("test@nimblehq.co")
+        signingViewModel.input.password("12345678")
 
         // Assert
         enableLoginButtonObserver

--- a/data/src/production/java/co/nimblehq/data/api/common/secrets/ClientIdImpl.kt
+++ b/data/src/production/java/co/nimblehq/data/api/common/secrets/ClientIdImpl.kt
@@ -2,5 +2,5 @@ package co.nimblehq.data.api.common.secrets
 
 class ClientIdImpl : ClientId {
     override val value: String
-        get() = "OAGS3tuneJ754D0lrY5JiM8BQbYlbgGXcrcxXtEE4hk"
+        get() = "3Xb-UMGcZCp2V83lwOEL1j5IYOHo1eJu4B-NWwaJoF4"
 }

--- a/data/src/production/java/co/nimblehq/data/api/common/secrets/ClientSecretImpl.kt
+++ b/data/src/production/java/co/nimblehq/data/api/common/secrets/ClientSecretImpl.kt
@@ -2,5 +2,5 @@ package co.nimblehq.data.api.common.secrets
 
 class ClientSecretImpl : ClientSecret {
     override val value: String
-        get() = "bjwBZpkdWGjVFCFbJ7rHWPVLDO-UffRz4T1k6QvqOeM"
+        get() = "bOAzK1CiqLm0vhKBHoj_TGVkG75SqmNrQA8aPVU-JIk"
 }


### PR DESCRIPTION
## What happened

Just a small refactor work regarding the ViewModels incoming and outgoing communications, update Production's clientId & secrets and fix some warnings. To add more context:

- Implemented Output interfaces for ViewModels, help group output Observables for better code structuring (similar with DeeMoney Android project)
 - Add `Locale.getDefault()` to `toUpperCase` function for strings to remove warnings.
- Update app with valid `ClientId` and `Secret` for OAuth2 authentication with Production server.
 
## Proof Of Work

The application should be built and functioning normally. Just code refactor and no visible changes.
